### PR TITLE
Review of strings.dtd for french

### DIFF
--- a/chrome/locale/fr/strings.dtd
+++ b/chrome/locale/fr/strings.dtd
@@ -1,9 +1,9 @@
-<!ENTITY mailhops_header_route_label           "Route MailHops">
-<!ENTITY mailhops_header_auth_label            "Authentifications MailHops">
-<!ENTITY mailhops_header_meta_label            "Meta MailHops">
-<!ENTITY mailhops_route_nav_map_label          "Carte">
+<!ENTITY mailhops_header_route_label           "Trajet">
+<!ENTITY mailhops_header_auth_label            "Authentification">
+<!ENTITY mailhops_header_meta_label            "Autres données">
+<!ENTITY mailhops_route_nav_map_label          "Afficher la Carte">
 <!ENTITY mailhops_route_nav_details_label      "Détails">
-<!ENTITY mailhops_route_nav_refresh_label      "Rafraîchir">
+<!ENTITY mailhops_route_nav_refresh_label      "Actualiser">
 <!ENTITY mailhops_route_nav_options_label      "Options">
 <!ENTITY mailhops_unsubscribe                  "Se désabonner">
-<!ENTITY mailhops_hops                         "Houblon">
+<!ENTITY mailhops_hops                         "Étapes">


### PR DESCRIPTION
File reviewed. Thanks for the new translatable string ;-).

Translation process can be improved; please do not use automated translation => add strings in files, left them empty and in the code use english strings if no local string is found. Otherwise your plugin may become unusable after translation. For instance 'hops' can not be translated by 'houblon' which is, in french, the main cereal component for BIER that's the reason why it has no plural in french ;-).

Best regards,