### PR TITLE
Misc. bug fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,4 @@ filename='mailhops'
 
 rm -f $filename.zip
 
-zip -r $filename.zip ./ -i *.js *.xhtml *.html *.png *.svg *.gif *.css *.json *.dtd _locales/*/messages.json
+zip -r $filename.zip ./ -i '*.js' '*.xhtml' '*.html' '*.png' '*.svg' '*.gif' '*.css' '*.json' '*.dtd'

--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,4 @@ filename='mailhops'
 
 rm -f $filename.zip
 
-zip -r $filename.zip ./ -i *.js *.xhtml *.html *.png *.svg *.gif *.css *.json _locales/*/messages.json
+zip -r $filename.zip ./ -i *.js *.xhtml *.html *.png *.svg *.gif *.css *.json *.dtd _locales/*/messages.json

--- a/js/mailhops.js
+++ b/js/mailhops.js
@@ -10,7 +10,7 @@ class MailHops {
   loading = false
   tabId = null
   options = {
-    version: 'MailHops Plugin 4.3.3',
+    version: 'MailHops Plugin 4.4.0',
     api_key: '',
     owm_key: '',
     lang: 'en',

--- a/js/mailhops_details.js
+++ b/js/mailhops_details.js
@@ -136,7 +136,7 @@ function updateContent(msg, noauth) {
           auth += '<label class="tiny ui label ' + msg.message.auth[a].color + '"><img src="' + msg.message.auth[a].icon + '"/>' + msg.message.auth[a].type + ' ' + msg.message.auth[a].copy + '</label>';          
         }
         else if (msg.message.auth[a].link) {
-          if (msg.message.auth[a].link.indexOf(',')) {
+          if (-1 !== msg.message.auth[a].link.indexOf(',')) {
             auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link.substr(0,msg.message.auth[a].link.indexOf(','))+'" target="_blank">' + msg.message.auth[a].type + '</a>';            
           }
           else {


### PR DESCRIPTION
This PR bundles a few bug fixes, namely:

  - fixing `build.sh` to include `*.dtd` files and generally keep the shell from interpreting file names, so that zip handles them correctly
  - fixing inverted logic when parsing links with a comma in the presentation layer (`js/mailhops_details.js`)
  - syncing up version number in `js/mailhops.js` and `manifest.json`

There are more things to come, but I'll PR them as we merge things!