### PR TITLE
Show local data on error

### DIFF
--- a/js/mailhops_details.js
+++ b/js/mailhops_details.js
@@ -129,25 +129,26 @@ function updateContent(msg, noauth) {
       asn = '<br/>ASN Org: ' + MailHopsUtils.htmlEncode(route[i].asn.autonomous_system_organization);
       asn += ' (<a href="https://dnschecker.org/asn-whois-lookup.php?query='+route[i].asn.autonomous_system_number+'" target="_blank" title="ASN Lookup">' + route[i].asn.autonomous_system_number + '</a>)'
     }
-    
-    var auth = '';
-    if (!noauth && msg.message.auth.length) {
-      for (var a = 0; a < msg.message.auth.length; a++){
-        if (msg.message.auth[a].icon) {
-          auth += '<label class="tiny ui label ' + msg.message.auth[a].color + '"><img src="' + msg.message.auth[a].icon + '"/>' + msg.message.auth[a].type + ' ' + msg.message.auth[a].copy + '</label>';          
+
+    // append child
+    items.push('<div class="item"><div class="content"><div class="header"><img src="'+ icon + '" /> ' + header + weather +' <label class="ui circular label icon" style="float: right;">'+ (i + 1) +'</label></div><div class="description">'+ description + asn + '</div></div></div>');
+  }
+
+  var auth = '';
+  if (!noauth && msg.message.auth.length) {
+    for (var a = 0; a < msg.message.auth.length; a++){
+      if (msg.message.auth[a].icon) {
+        auth += '<label class="tiny ui label ' + msg.message.auth[a].color + '"><img src="' + msg.message.auth[a].icon + '"/>' + msg.message.auth[a].type + ' ' + msg.message.auth[a].copy + '</label>';
+      }
+      else if (msg.message.auth[a].link) {
+        if (-1 !== msg.message.auth[a].link.indexOf(',')) {
+          auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link.substr(0,msg.message.auth[a].link.indexOf(','))+'" target="_blank">' + msg.message.auth[a].type + '</a>';
         }
-        else if (msg.message.auth[a].link) {
-          if (-1 !== msg.message.auth[a].link.indexOf(',')) {
-            auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link.substr(0,msg.message.auth[a].link.indexOf(','))+'" target="_blank">' + msg.message.auth[a].type + '</a>';            
-          }
-          else {
-            auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link+'" target="_blank">' + msg.message.auth[a].type + '</a>';            
-          }
+        else {
+          auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link+'" target="_blank">' + msg.message.auth[a].type + '</a>';
         }
       }
     }
-    // append child
-    items.push('<div class="item"><div class="content"><div class="header"><img src="'+ icon + '" /> ' + header + weather +' <label class="ui circular label icon" style="float: right;">'+ (i + 1) +'</label></div><div class="description">'+ description + asn + '</div></div></div>');    
   }
 
   // header

--- a/js/mailhops_details.js
+++ b/js/mailhops_details.js
@@ -47,10 +47,11 @@ function updateContent(msg, noauth) {
     document.getElementById('hop-message').classList.add('warning');
     document.getElementById('mh-map-button').style.display = 'none';    
     document.getElementById('hop-message-header').innerHTML = msg.message.error;
-    return;
   }
-  document.getElementById('hop-message').classList.remove('warning');
-  document.getElementById('mh-map-button').style.display = 'inline-block';
+  else {
+    document.getElementById('hop-message').classList.remove('warning');
+    document.getElementById('mh-map-button').style.display = 'inline-block';
+  }
   
   const route = msg.response.route || [];
   const sender = msg.message.sender || null;
@@ -148,10 +149,13 @@ function updateContent(msg, noauth) {
     // append child
     items.push('<div class="item"><div class="content"><div class="header"><img src="'+ icon + '" /> ' + header + weather +' <label class="ui circular label icon" style="float: right;">'+ (i + 1) +'</label></div><div class="description">'+ description + asn + '</div></div></div>');    
   }
+
   // header
-  document.getElementById('hop-message-header').innerHTML = `${route.length} Hops`;
-  if (sender && client) {    
-    document.getElementById('hop-message-header').innerHTML += ' over '+MailHopsUtils.getDistance(sender, client, unit) + ' ' + unit;    
+  if (!msg.message.error) {
+    document.getElementById('hop-message-header').innerHTML = `${route.length} Hops`;
+    if (sender && client) {
+      document.getElementById('hop-message-header').innerHTML += ' over '+MailHopsUtils.getDistance(sender, client, unit) + ' ' + unit;
+    }
   }
 
   // hop list


### PR DESCRIPTION
Previously, when the API was unreachable or returned an error, the whole popup was disabled without even processing local data or applying the theme option.

Since auth data is local data and we want to always apply the theme option correctly, don't return early in case of an error but only guard code that would fail if we don't have an API response.

Depends upon #32.