### PR TITLE
Rework Received-SPF header parsing.

### DIFF
--- a/content/preferences.html
+++ b/content/preferences.html
@@ -136,6 +136,22 @@
 					</div>
 					<p>Flag messages as junk if travel time takes longer than normal.</p>
 				</div>
+				<div class="grouped fields">
+					<div class="field">
+						<label>Additional information</label>
+						<div class="ui radio checkbox">
+							<input type="radio" id="extrainfo_on" name="extrainfo" value="on" />
+							<label for="extrainfo_on">Show</label>
+						</div>
+					</div>
+					<div class="field">
+						<div class="ui radio checkbox">
+							<input type="radio" id="extrainfo_off" name="extrainfo" value="off" />
+							<label for="extrainfo_off">Hide</label>
+						</div>
+					</div>
+					<p>Show additional information in authentication results, typically contains more header content.</p>
+				</div>
 				<div class="grouped fields">					
 					<div class="field">
 						<label>Debug Messages</label>

--- a/js/mailhops.js
+++ b/js/mailhops.js
@@ -308,8 +308,8 @@ class MailHops {
       auth.push({
         type: 'SPF',
         color: 'green',
-        icon: '/images/auth/' + headerSPFArr[0] + '.png',
-        copy: header_spf + '\n' + MailHopsUtils.spf(headerSPFArr[0]).trim()
+        icon: '/images/auth/' + headerSPFArr[0].toLowerCase () + '.png',
+        copy: header_spf + '\n' + MailHopsUtils.spf(headerSPFArr[0].toLowerCase ()).trim()
       });
     }
     //Authentication-Results

--- a/js/mailhops.js
+++ b/js/mailhops.js
@@ -18,8 +18,9 @@ class MailHops {
     theme: 'light',
     api_http: 'https://',
     api_host: 'api.Mailhops.com',
-    debug: false,
     travel_time_junk: false,
+    extrainfo: false,
+    debug: false,
     country_filter: []
   }
   message = {
@@ -67,6 +68,9 @@ class MailHops {
       }
       if (data.travel_time_junk && data.travel_time_junk != 'off') {
         this.options.travel_time_junk = Boolean(data.travel_time_junk);
+      }
+      if (data.extrainfo) {
+        this.options.extrainfo = Boolean(data.extrainfo);
       }
       if (data.debug) {
         this.options.debug = Boolean(data.debug);

--- a/js/mailhops_details.js
+++ b/js/mailhops_details.js
@@ -57,6 +57,7 @@ function updateContent(msg, noauth) {
   const sender = msg.message.sender || null;
   const unit = msg.options.unit || "mi";
   const theme = msg.options.theme || "light";
+  const debug = msg.options.debug || false;
   let client = null;
   let items = [];
   
@@ -138,15 +139,24 @@ function updateContent(msg, noauth) {
   if (!noauth && msg.message.auth.length) {
     for (var a = 0; a < msg.message.auth.length; a++){
       if (msg.message.auth[a].icon) {
-        auth += '<label class="tiny ui label ' + msg.message.auth[a].color + '"><img src="' + msg.message.auth[a].icon + '"/>' + msg.message.auth[a].type + ' ' + msg.message.auth[a].copy + '</label>';
+        var add = '<label class="tiny ui label ' + msg.message.auth[a].color + '"><img src="' + msg.message.auth[a].icon + '"/>' + msg.message.auth[a].type + ' ' + msg.message.auth[a].copy + '</label>';
+        if (debug) {
+          console.log("adding to auth (type icon): '" + add + "'");
+        }
+        auth += add;
       }
       else if (msg.message.auth[a].link) {
-        if (-1 !== msg.message.auth[a].link.indexOf(',')) {
-          auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link.substr(0,msg.message.auth[a].link.indexOf(','))+'" target="_blank">' + msg.message.auth[a].type + '</a>';
+        var add = '';
+        if (-1 != msg.message.auth[a].link.indexOf(',')) {
+          add = '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link.substr(0,msg.message.auth[a].link.indexOf(','))+'" target="_blank">' + msg.message.auth[a].type + '</a>';
         }
         else {
-          auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link+'" target="_blank">' + msg.message.auth[a].type + '</a>';
+          add = '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link+'" target="_blank">' + msg.message.auth[a].type + '</a>';
         }
+        if (debug) {
+          console.log("adding to auth (type link): '" + add + "'");
+        }
+        auth += add;
       }
     }
   }

--- a/js/mailhops_details.js
+++ b/js/mailhops_details.js
@@ -129,25 +129,26 @@ function updateContent(msg, noauth) {
       asn = '<br/>ASN Org: ' + MailHopsUtils.htmlEncode(route[i].asn.autonomous_system_organization);
       asn += ' (<a href="https://dnschecker.org/asn-whois-lookup.php?query='+route[i].asn.autonomous_system_number+'" target="_blank" title="ASN Lookup">' + route[i].asn.autonomous_system_number + '</a>)'
     }
-    
-    var auth = '';
-    if (!noauth && msg.message.auth.length) {
-      for (var a = 0; a < msg.message.auth.length; a++){
-        if (msg.message.auth[a].icon) {
-          auth += '<label class="tiny ui label ' + msg.message.auth[a].color + '"><img src="' + msg.message.auth[a].icon + '"/>' + msg.message.auth[a].type + ' ' + msg.message.auth[a].copy + '</label>';          
+
+    // append child
+    items.push('<div class="item"><div class="content"><div class="header"><img src="'+ icon + '" /> ' + header + weather +' <label class="ui circular label icon" style="float: right;">'+ (i + 1) +'</label></div><div class="description">'+ description + asn + '</div></div></div>');
+  }
+
+  var auth = '';
+  if (!noauth && msg.message.auth.length) {
+    for (var a = 0; a < msg.message.auth.length; a++){
+      if (msg.message.auth[a].icon) {
+        auth += '<label class="tiny ui label ' + msg.message.auth[a].color + '"><img src="' + msg.message.auth[a].icon + '"/>' + msg.message.auth[a].type + ' ' + msg.message.auth[a].copy + '</label>';
+      }
+      else if (msg.message.auth[a].link) {
+        if (-1 !== msg.message.auth[a].link.indexOf(',')) {
+          auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link.substr(0,msg.message.auth[a].link.indexOf(','))+'" target="_blank">' + msg.message.auth[a].type + '</a>';
         }
-        else if (msg.message.auth[a].link) {
-          if (-1 !== msg.message.auth[a].link.indexOf(',')) {
-            auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link.substr(0,msg.message.auth[a].link.indexOf(','))+'" target="_blank">' + msg.message.auth[a].type + '</a>';            
-          }
-          else {
-            auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link+'" target="_blank">' + msg.message.auth[a].type + '</a>';            
-          }
+        else {
+          auth += '<a class="tiny ui label ' + msg.message.auth[a].color + '" href="'+msg.message.auth[a].link+'" target="_blank">' + msg.message.auth[a].type + '</a>';
         }
       }
     }
-    // append child
-    items.push('<div class="item"><div class="content"><div class="header"><img src="'+ icon + '" /> ' + header + weather +' <label class="ui circular label icon" style="float: right;">'+ (i + 1) +'</label></div><div class="description">'+ description + asn + '</div></div></div>');    
   }
 
   // header

--- a/js/mailhops_details.js
+++ b/js/mailhops_details.js
@@ -47,10 +47,11 @@ function updateContent(msg, noauth) {
     document.getElementById('hop-message').classList.add('warning');
     document.getElementById('mh-map-button').style.display = 'none';    
     document.getElementById('hop-message-header').innerHTML = msg.message.error;
-    return;
   }
-  document.getElementById('hop-message').classList.remove('warning');
-  document.getElementById('mh-map-button').style.display = 'inline-block';
+  else {
+    document.getElementById('hop-message').classList.remove('warning');
+    document.getElementById('mh-map-button').style.display = 'inline-block';
+  }
   
   const route = msg.response.route || [];
   const sender = msg.message.sender || null;
@@ -148,10 +149,13 @@ function updateContent(msg, noauth) {
     // append child
     items.push('<div class="item"><div class="content"><div class="header"><img src="'+ icon + '" /> ' + header + weather +' <label class="ui circular label icon" style="float: right;">'+ (i + 1) +'</label></div><div class="description">'+ description + asn + '</div></div></div>');    
   }
+
   // header
-  document.getElementById('hop-message-header').innerHTML = `${route.length} Hops`;
-  if (sender && client) {    
-    document.getElementById('hop-message-header').innerHTML += ' over '+MailHopsUtils.getDistance(sender, client, unit) + ' ' + unit;    
+  if (!msg.message.error) {
+    document.getElementById('hop-message-header').innerHTML = `${route.length} Hops`;
+    if (sender && client) {
+      document.getElementById('hop-message-header').innerHTML += ' over '+MailHopsUtils.getDistance(sender, client, unit) + ' ' + unit;
+    }
   }
 
   // hop list

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -3,8 +3,9 @@ const MailHopPreferences = {
   valid_api_key: false,
   unit: 'mi',
   theme: 'light',
-  debug: false,
   travel_time_junk: false,
+  extrainfo: false,
+  debug: false,
   owm_key: '', //OpenWeatherMap.org api key
   countries: [],
   
@@ -78,6 +79,7 @@ const MailHopPreferences = {
     this.theme = data.theme || 'light';
     this.unit = data.unit || 'mi';
     this.travel_time_junk = Boolean(data.travel_time_junk);
+    this.extrainfo = Boolean(data.extrainfo);
     this.debug = Boolean(data.debug);
     
     if (data.countries) {
@@ -123,6 +125,11 @@ const MailHopPreferences = {
     else
       document.getElementById("travel_time_junk_off").setAttribute('checked', 'checked');
     
+    if (this.extrainfo)
+      document.getElementById("extrainfo_on").setAttribute('checked', 'checked');
+    else
+      document.getElementById("extrainfo_off").setAttribute('checked', 'checked');
+
     if (this.debug)
       document.getElementById("debug_on").setAttribute('checked', 'checked');
     else
@@ -209,6 +216,7 @@ const MailHopPreferences = {
       unit: document.querySelector('input[name="unit"]:checked').value,
       theme: document.querySelector('input[name="theme"]:checked').value,
       travel_time_junk: document.querySelector('input[name="travel_time_junk"]:checked').value == 'on' ? true : false,
+      extrainfo: document.querySelector('input[name="extrainfo"]:checked').value == 'on' ? true : false,
       debug: document.querySelector('input[name="debug"]:checked').value == 'on' ? true : false,
       countries: self.countries.join(','),
     });    


### PR DESCRIPTION
Instead of just extracting the state itself, we'll also fetch the reason (typically parenthesis-enclosed) and use the rest of the header as additional data, which is only shown if the `extrainfo` preference has been turned on.

Depends on #35.